### PR TITLE
Force uppercase on input without affecting placeholder text

### DIFF
--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -58,4 +58,14 @@ function TlaViewModel() {
 
 jQuery(document).ready(function() {
     ko.applyBindings(TlaViewModel());
+
+    $("#AcronymInput").on('input', function(evt) {
+        var input = $(this);
+        var start = input[0].selectionStart;
+        $(this).val(function (_, val) {
+            return val.toUpperCase();
+        });
+        input[0].selectionStart = input[0].selectionEnd = start;
+    });
+
 });

--- a/views/index.erb
+++ b/views/index.erb
@@ -36,6 +36,7 @@
                      onfocus="placeholder = '';" 
                      onblur="placeholder = 'Enter TLA...';" 
                      class="form-control input-lg" 
+                     id="AcronymInput"
                      type="text">
                   </div>
 


### PR DESCRIPTION
Experimental terrible way of handling input AND retaining cursor position within the text while converting all characters to uppercase.

It's super hacky and very inelegant, but I thought I'd put it here to see if it can be refined.

I don't like the fact we're hacking in some custom jQuery and require the element to have an ID - I would prefer it stay within the KO framework for completeness.

Mistakes likely - I stole this from google and applied changes rapidly
